### PR TITLE
Fix: Never silence warnings, always check ruff docs for fixes

### DIFF
--- a/{{cookiecutter.project_slug}}/.opencode/skills/code-quality/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.opencode/skills/code-quality/SKILL.md
@@ -264,6 +264,25 @@ jobs:
 
 ### 8. Quality Issue Resolution
 
+#### CRITICAL: Never Silence Warnings with noqa
+**Golden Rule**: When ruff reports an issue, ALWAYS check the documentation to understand how to fix it properly. Never use `noqa` comments to silence warnings.
+
+For any ruff rule (like RUF069, F841, etc.):
+1. Look up the rule at https://docs.astral.sh/ruff/rules/
+2. Read the "How to fix" section
+3. Apply the proper solution
+4. Only use noqa as a last resort when no proper fix exists
+
+Example workflow for RUF069 (float-equality-comparison):
+```bash
+# WRONG - just silencing the warning
+assert value == 10.0  # noqa: RUF069
+
+# RIGHT - using math.isclose() as per ruff docs
+import math
+assert math.isclose(value, 10.0, abs_tol=1e-9)
+```
+
 #### Common Ruff Issues and Fixes
 ```python
 # Issue: ANN001 - Missing type hint for function argument

--- a/{{cookiecutter.project_slug}}/.opencode/skills/tdd/SKILL.md
+++ b/{{cookiecutter.project_slug}}/.opencode/skills/tdd/SKILL.md
@@ -38,6 +38,24 @@ For complete test patterns and guidelines, see:
 3. **Refactor** (REFACTOR phase)
    - Improve code while keeping tests green
 
+## CRITICAL: Handle Lint Warnings Properly
+
+When writing tests, ruff may report issues like RUF069 (float-equality-comparison). 
+
+**NEVER use noqa to silence warnings.** Instead:
+1. Check the rule at https://docs.astral.sh/ruff/rules/<RULE_CODE>/
+2. Apply the proper fix from the "How to fix" section
+
+Example for RUF069 (float-equality):
+```python
+# WRONG - silencing
+assert bond.amount_usdt == 10.0  # noqa: RUF069
+
+# RIGHT - using math.isclose()
+import math
+assert math.isclose(bond.amount_usdt, 10.0, abs_tol=1e-9)
+```
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- Add critical rule to code-quality skill: never use noqa to silence warnings
- Add section to tdd skill about handling lint warnings properly
- Example: RUF069 (float-equality) now uses math.isclose() instead of noqa

## Changes
- `{{cookiecutter.project_slug}}/.opencode/skills/code-quality/SKILL.md`: Added "CRITICAL: Never Silence Warnings with noqa" section with workflow
- `{{cookiecutter.project_slug}}/.opencode/skills/tdd/SKILL.md`: Added section on handling lint warnings with RUF069 example