### PR TITLE
fix: update release version to v1.5.20260403r1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ cookiecutter gh:your-username/python-project-template --checkout v1.2.20260312
 - **v1.2.20260312**: Added meta template management system
 - **v1.3.20260313**: Added session-workflow skill
 - **v1.4.20260313**: Added AI-driven themed naming
-- **v1.5.20260402**: Replaced mkdocs with pdoc for API docs, added pytest-html-plus with BDD docstring display
+- **v1.5.20260403r1**: Replaced mkdocs with pdoc for API docs, added pytest-html-plus with BDD docstring display
 
 ## Generated Project Features
 


### PR DESCRIPTION
Fix release tag to follow standard versioning format: v{major}.{minor}.{YYYYMMDD}r{revision}