### PR TITLE
fix: doc-publish task now runs doc-build first

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -152,13 +152,14 @@ lint = "task ruff-check && task ruff-format"
 doc-serve = "pdoc ./{{cookiecutter.package_name}} --host localhost --port 8080"
 doc-build = "pdoc ./{{cookiecutter.package_name}} -o docs/api --search"
 doc-publish = """\
-git checkout gh-pages || git checkout -b gh-pages && \
+task doc-build && \
+git checkout gh-pages 2>/dev/null || git checkout -b gh-pages && \
 git rm -rf . && \
 cp -r docs/api/* . && \
 git add -A && \
 git commit -m "Publish API documentation" && \
 git push origin gh-pages --force && \
-git checkout -"""
+git checkout main"""
 mut-report = """
   uv run cosmic-ray new-config mut.toml && \
   uv run cosmic-ray init mut.toml mut.sqlite && \


### PR DESCRIPTION
Fix the doc-publish task to build the docs before publishing to gh-pages branch.