### PR TITLE
fix: use docs branch for GitHub Pages

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -153,12 +153,12 @@ doc-serve = "pdoc ./{{cookiecutter.package_name}} --host localhost --port 8080"
 doc-build = "pdoc ./{{cookiecutter.package_name}} -o docs/api --search"
 doc-publish = """\
 task doc-build && \
-git checkout gh-pages 2>/dev/null || git checkout -b gh-pages && \
+git checkout docs 2>/dev/null || git checkout -b docs && \
 git rm -rf . && \
 cp -r docs/api/* . && \
 git add -A && \
 git commit -m "Publish API documentation" && \
-git push origin gh-pages --force && \
+git push origin docs --force && \
 git checkout main"""
 mut-report = """
   uv run cosmic-ray new-config mut.toml && \


### PR DESCRIPTION
Use docs branch instead of gh-pages to match GitHub Pages source configuration