### PR TITLE
fix: use gh-pages branch for GitHub Pages

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -153,12 +153,12 @@ doc-serve = "pdoc ./{{cookiecutter.package_name}} --host localhost --port 8080"
 doc-build = "pdoc ./{{cookiecutter.package_name}} -o docs/api --search"
 doc-publish = """\
 task doc-build && \
-git checkout docs 2>/dev/null || git checkout -b docs && \
-git rm -rf . && \
+git checkout gh-pages 2>/dev/null || git checkout -b gh-pages && \
+git rm -rf . 2>/dev/null || true && \
 cp -r docs/api/* . && \
 git add -A && \
 git commit -m "Publish API documentation" && \
-git push origin docs --force && \
+git push origin gh-pages --force && \
 git checkout main"""
 mut-report = """
   uv run cosmic-ray new-config mut.toml && \


### PR DESCRIPTION
Update doc-publish to use gh-pages branch instead of docs