### PR TITLE
fix: use hybrid calver instead of patch in version patterns

### DIFF
--- a/.opencode/agents/repo-manager.md
+++ b/.opencode/agents/repo-manager.md
@@ -31,18 +31,18 @@ As a Release Engineer focused on the template repository:
 
 ## Template Versioning Strategy
 
-For the cookiecutter template repository, use semantic versioning: `v{major}.{minor}.{patch}`
+For the cookiecutter template repository, use hybrid calver: `v{major}.{minor}.{YYYYMMDD}`
 
 **Version Semantics:**
 - **Major**: Breaking changes to template structure or cookiecutter variables
 - **Minor**: New features (agents, skills, workflows) - backward compatible
-- **Patch**: Bug fixes, documentation updates, minor improvements
+- **Calver**: Calendar date of release (YYYYMMDD)
 
 **Examples:**
-- `v1.0.0` - Initial stable template release
-- `v1.1.0` - Added new agent capabilities
-- `v1.1.1` - Fixed documentation typos
-- `v2.0.0` - Changed cookiecutter.json structure
+- `v1.0.20260312` - Initial release on March 12, 2026
+- `v1.1.20260315` - Added new agent capabilities on March 15
+- `v1.2.20260315` - Second release same day (increment minor)
+- `v2.0.20260401` - Changed cookiecutter.json structure on April 1
 
 ## Release Engineering Standards
 
@@ -95,7 +95,7 @@ For the cookiecutter template repository, use semantic versioning: `v{major}.{mi
    ```bash
    git checkout develop
    git pull origin develop
-   git checkout -b release/v{major}.{minor}.{patch}
+   git checkout -b release/v{major}.{minor}.{YYYYMMDD}
    ```
 
 2. **Changelog Generation**

--- a/.opencode/agents/template-manager.md
+++ b/.opencode/agents/template-manager.md
@@ -54,7 +54,7 @@ python-project-template/
 ## Release Engineering Process
 
 ### Semantic Versioning Strategy
-Following SemVer 2.0.0 specification: `v{major}.{minor}.{patch}`
+Following hybrid calver specification: `v{major}.{minor}.{YYYYMMDD}`
 - **Major (Breaking)**: API changes, cookiecutter variable modifications, structural changes
 - **Minor (Feature)**: New capabilities, agents, skills, backward-compatible enhancements
 - **Patch (Fix)**: Bug fixes, documentation updates, security patches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this template will be documented in this file.
 
+## [v1.7.20260410] - Vivid Cardinal - 2026-04-10
+
+### Added
+- **QA-gated Epic Workflow** - Complete epic-based development with mandatory quality checkpoints at each phase
+- **Epic-workflow Skill** - Manages epic-based development with automatic feature progression
+- **EPICS.md Template** - Epic tracking and management file for generated projects
+
+### Changed
+- Updated all agent descriptions to use industry-standard roles (Development Lead, Software Architect, QA Specialist, Business Analyst, Release Engineer)
+- Removed model specifications from all agents to make template model-agnostic
+- Updated AGENTS.md to properly document all 5 generated project agents and all skills
+- Updated README.md with new workflow and agent roles
+
+### Fixed
+- Documentation now accurately reflects what exists in template
+
 ## [v1.6.20260409] - Guardian Owl - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 > **Ship production-ready Python projects faster with AI-powered development workflows**
 
+### Latest Release: [v1.7.20260410](https://github.com/nullhack/python-project-template/releases/tag/v1.7.20260410) - Vivid Cardinal
+
 Modern cookiecutter template delivering enterprise-grade Python projects with **OpenCode AI agents**, **TDD/BDD workflows**, and **zero-config quality standards**.
 
 ## ✨ What You Get


### PR DESCRIPTION
## Summary
Hotfix to correct version pattern discrepancies.

### Changes
- Changed version format from `v{major}.{minor}.{patch}` to `v{major}.{minor}.{YYYYMMDD}`
- Updated template-manager agent
- Updated repo-manager agent
- Now consistent with generated project versioning (hybrid calver)

This hotfix merges into the release branch.