### PR TITLE
fix: remove invalid security-updates group from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 version: 2
-# SECURITY: Automated dependency updates with security-focused grouping
+# Automated dependency updates for Python packages
 updates:
   # Enable version updates for Python packages
   - package-ecosystem: "pip"
@@ -27,11 +27,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      security-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "security"
     # Configuration options
     open-pull-requests-limit: 5
     # Allow auto-merge for security updates


### PR DESCRIPTION
## Summary
- Remove invalid `security-updates` group from dependabot configuration
- The group used `update-types: ["security"]` which is not a valid value
- Valid values are: `major`, `minor`, `patch`
- Keep the valid `dev-dependencies` group for development tool updates

## Changes
- Removed invalid security-updates group (6 lines)
- Updated comment to reflect actual behavior

## Testing
- YAML syntax validated
- Only uses valid update-types values
- Security updates will run individually (recommended approach)

## Related
- Fixes dependabot validation error
- Resolves the 1 moderate vulnerability warning by allowing dependabot to work