### PR TITLE
fix(naming): replace stale developer role references; agent-name placeholders in session-workflow

### DIFF
--- a/.opencode/skills/implementation/SKILL.md
+++ b/.opencode/skills/implementation/SKILL.md
@@ -11,7 +11,7 @@ workflow: feature-lifecycle
 
 Steps 2 (Architecture) and 3 (TDD Loop) combined into a single skill. The software-engineer owns both.
 
-## Developer Quality Gate Priority Order
+## Software-Engineer Quality Gate Priority Order
 
 During implementation, correctness priorities are (in order):
 

--- a/.opencode/skills/session-workflow/SKILL.md
+++ b/.opencode/skills/session-workflow/SKILL.md
@@ -73,11 +73,12 @@ Source: docs/features/in-progress/<name>.feature
 Run @<agent-name> — <one concrete action>
 ```
 
-**"Next" line format**: Always prefix with `Run @<agent-name>` so the human knows exactly which agent to invoke. Examples:
-- `Run @software-engineer — implement @id:a1b2c3d4 (Step 3 RED)`
-- `Run @reviewer — verify feature display-version at Step 4`
-- `Run @product-owner — pick next BASELINED feature from backlog`
-- `Run @product-owner — accept feature display-version at Step 5`
+**"Next" line format**: Always prefix with `Run @<agent-name>` so the human knows exactly which agent to invoke. Agent names are defined in `AGENTS.md` — use the name exactly as listed there. Examples:
+- `Run @<software-engineer-agent> — implement @id:a1b2c3d4 (Step 3 RED)`
+- `Run @<software-engineer-agent> — load skill implementation and begin Step 2 (Architecture) for <feature-name>`
+- `Run @<reviewer-agent> — verify feature <feature-name> at Step 4`
+- `Run @<product-owner-agent> — pick next BASELINED feature from backlog`
+- `Run @<product-owner-agent> — accept feature <feature-name> at Step 5`
 
 **Source path by step:**
 - Step 1: `Source: docs/features/backlog/<name>.feature`
@@ -95,7 +96,7 @@ When no feature is active:
 # Current Work
 
 No feature in progress.
-Next: Run @product-owner — load skill feature-selection and pick the next BASELINED feature from backlog.
+Next: Run @<product-owner-agent> — load skill feature-selection and pick the next BASELINED feature from backlog.
 ```
 
 ## Step 3 (TDD Loop) Cycle-Aware TODO Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this template will be documented in this file.
 
+## [v5.2.20260418] - Emergent Colugo - 2026-04-18 (hotfix)
+
+### Fixed
+- **Role naming**: Replaced stale `developer` agent-role references with `software-engineer` in `implementation/SKILL.md`, `docs/scientific-research/ai-agents.md`, `docs/scientific-research/cognitive-science.md`, and `docs/features/completed/display-version.feature`
+- **session-workflow**: Replaced hardcoded agent names in `## Next` line examples with `@<agent-name>` placeholders; added note pointing to `AGENTS.md` as source of truth; added missing Step 2 (Architecture) example
+
 ## [v5.1.20260418] - Emergent Colugo - 2026-04-18
 
 ### Added

--- a/docs/features/completed/display-version.feature
+++ b/docs/features/completed/display-version.feature
@@ -36,7 +36,7 @@ Feature: Display version
   All questions answered. Discovery frozen.
 
   Rule: Version retrieval
-    As a developer
+    As a software-engineer
     I want to retrieve the application version programmatically
     So that I can display or log it at runtime
 
@@ -53,7 +53,7 @@ Feature: Display version
       Then an INFO log message in the format "Version: <version>" is emitted
 
   Rule: Verbosity control
-    As a developer
+    As a software-engineer
     I want to control log verbosity via a parameter
     So that I can tune output for different environments
 

--- a/docs/scientific-research/ai-agents.md
+++ b/docs/scientific-research/ai-agents.md
@@ -14,7 +14,7 @@ Foundations for the agent architecture, file structure, and context management d
 | **Status** | Confirmed — corrects the belief that subagents should be "lean routing agents" |
 | **Core finding** | "Define the smallest agent that can own a clear task. Add more agents only when you need separate ownership, different instructions, different tool surfaces, or different approval policies." The split criterion is ownership boundary, not instruction volume. |
 | **Mechanism** | Multiple agents competing to own the same concern create authority conflicts and inconsistent tool access. The right unit is the smallest coherent domain that requires exclusive responsibility. |
-| **Where used** | Agent design in `.opencode/agents/*.md` — 4 agents, each owning a distinct domain (PO, developer, reviewer, setup). |
+| **Where used** | Agent design in `.opencode/agents/*.md` — 4 agents, each owning a distinct domain (PO, software-engineer, reviewer, setup). |
 
 ---
 

--- a/docs/scientific-research/cognitive-science.md
+++ b/docs/scientific-research/cognitive-science.md
@@ -13,7 +13,7 @@ Mechanisms from cognitive and social psychology that justify workflow design dec
 | **Status** | Confirmed |
 | **Core finding** | Asking "imagine this failed — why?" catches 30% more issues than forward-looking review. |
 | **Mechanism** | Prospective hindsight shifts from prediction (weak) to explanation (strong). The brain is better at explaining past events than predicting future ones. By framing as "it already failed," you activate explanation mode. |
-| **Where used** | PO pre-mortem at scope, developer pre-mortem before handoff. |
+| **Where used** | PO pre-mortem at scope, software-engineer pre-mortem before handoff. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-project-template"
-version = "5.1.20260418"
+version = "5.2.20260418"
 description = "Python template with some awesome tools to quickstart any Python project"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "python-project-template"
-version = "5.1.20260418"
+version = "5.2.20260418"
 source = { virtual = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary

- Replace 4 stale `developer` agent-role references with `software-engineer` across `implementation/SKILL.md`, `docs/scientific-research/ai-agents.md`, `docs/scientific-research/cognitive-science.md`, and `docs/features/completed/display-version.feature`
- Replace hardcoded agent names (`@software-engineer`, `@product-owner`, `@reviewer`) in `session-workflow/SKILL.md` `## Next` line examples with `@<agent-name>` placeholders so the skill stays correct if agents are renamed; add note pointing to `AGENTS.md` as source of truth; add missing Step 2 (Architecture) example
- Bump version to `v5.2.20260418` (hotfix on `v5.1.20260418 - Emergent Colugo`)

## Type

`fix` — corrects stale role names and fragile hardcoded agent references; no behaviour change