### PR TITLE
feat(workflow): add PO and reviewer self-declaration protocol

### DIFF
--- a/.opencode/agents/product-owner.md
+++ b/.opencode/agents/product-owner.md
@@ -25,7 +25,7 @@ Load `skill session-workflow` first — it reads TODO.md, orients you to the cur
 
 | Step | Action |
 |---|---|
-| **Step 1 — SCOPE** | Load `skill scope` — contains Stage 1 (Discovery sessions) and Stage 2 (Stories + Criteria) |
+| **Step 1 — SCOPE** | Load `skill scope` — contains Stage 1 (Discovery sessions) and Stage 2 (Stories + Criteria). At the end of Stage 2 Step B (criteria), write the `## Self-Declaration` block into `TODO.md` before committing — every DISAGREE is a hard blocker. |
 | **Step 5 — ACCEPT** | See acceptance protocol below |
 
 ## Ownership Rules

--- a/.opencode/skills/scope/SKILL.md
+++ b/.opencode/skills/scope/SKILL.md
@@ -279,6 +279,26 @@ All Rules must have their pre-mortems completed before any Examples are written.
 - [ ] Each Example is observably distinct from every other
 - [ ] No single feature file spans multiple unrelated concerns
 
+**Self-Declaration (mandatory before criteria commit)**
+
+Write the following block into `TODO.md` before committing. Every `DISAGREE` is a **hard blocker** — explain inline and fix before the commit. Do not commit until all items are AGREE or have a documented resolution.
+
+```markdown
+## Self-Declaration
+As a product-owner I declare:
+* INVEST-I: each Rule is Independent (no hidden ordering or dependency between Rules) — AGREE/DISAGREE | conflict:
+* INVEST-V: each Rule delivers Value to a named user — AGREE/DISAGREE | Rule:
+* INVEST-S: each Rule is Small enough for one development cycle — AGREE/DISAGREE | Rule:
+* INVEST-T: each Rule is Testable (I can write a pass/fail Example for it) — AGREE/DISAGREE | Rule:
+* Observable: every Then is a single, observable, measurable outcome — AGREE/DISAGREE | file:line
+* No impl details: no Example tests internal state or implementation — AGREE/DISAGREE | file:line
+* Coverage: every entity in the feature description appears in at least one Rule — AGREE/DISAGREE | missing:
+* Distinct: no two Examples test the same observable behavior — AGREE/DISAGREE | file:line
+* Unique IDs: all @id values are unique within this feature — AGREE/DISAGREE
+* Pre-mortem: I ran a pre-mortem on each Rule and found no hidden failure modes — AGREE/DISAGREE | Rule:
+* Scope: no Example introduces behavior outside the feature boundary — AGREE/DISAGREE | file:line
+```
+
 Commit: `feat(criteria): write acceptance criteria for <name>`
 
 **After this commit, `Example:` blocks are frozen.** Any change requires:

--- a/.opencode/skills/session-workflow/SKILL.md
+++ b/.opencode/skills/session-workflow/SKILL.md
@@ -104,6 +104,40 @@ No feature in progress.
 Next: Run @<product-owner-agent> — load skill feature-selection and pick the next BASELINED feature from backlog.
 ```
 
+## Step 1 (Stage 2 Criteria) Self-Declaration TODO Format
+
+When Stage 2 Step B (criteria) is complete and before the `feat(criteria):` commit, TODO.md **must** include a `## Self-Declaration` block written by the PO:
+
+```markdown
+# Current Work
+
+Feature: <name>
+Step: 1 (SCOPE — Stage 2 Criteria)
+Source: docs/features/backlog/<name>.feature
+
+## Self-Declaration
+As a product-owner I declare:
+* INVEST-I: each Rule is Independent — AGREE/DISAGREE | conflict:
+* INVEST-V: each Rule delivers Value to a named user — AGREE/DISAGREE | Rule:
+* INVEST-S: each Rule is Small enough for one development cycle — AGREE/DISAGREE | Rule:
+* INVEST-T: each Rule is Testable — AGREE/DISAGREE | Rule:
+* Observable: every Then is a single, observable, measurable outcome — AGREE/DISAGREE | file:line
+* No impl details: no Example tests internal state or implementation — AGREE/DISAGREE | file:line
+* Coverage: every entity in the feature description appears in at least one Rule — AGREE/DISAGREE | missing:
+* Distinct: no two Examples test the same observable behavior — AGREE/DISAGREE | file:line
+* Unique IDs: all @id values are unique within this feature — AGREE/DISAGREE
+* Pre-mortem: I ran a pre-mortem on each Rule and found no hidden failure modes — AGREE/DISAGREE | Rule:
+* Scope: no Example introduces behavior outside the feature boundary — AGREE/DISAGREE | file:line
+
+## Progress
+- [x] `@id:<hex>`: <description>
+
+## Next
+Run @<software-engineer-agent> — load skill implementation and begin Step 2 (Architecture) for <feature-name>
+```
+
+Every `DISAGREE` is a hard blocker — fix before committing.
+
 ## Step 3 (TDD Loop) Cycle-Aware TODO Format
 
 During Step 3 (TDD Loop), TODO.md **must** include a `## Cycle State` block to track Red-Green-Refactor progress.
@@ -166,3 +200,4 @@ Run `gen-todo` at session start (after reading TODO.md) and at session end (befo
 6. During Step 3, always update `## Cycle State` when transitioning between RED/GREEN/REFACTOR phases
 7. When a step completes, update TODO.md and commit **before** any further work
 8. During Step 3, write the `## Self-Declaration` block into TODO.md after all quality gates pass — every claim must have AGREE/DISAGREE with `file:line` evidence
+9. During Step 1 Stage 2 Step B (criteria), write the `## Self-Declaration` block into TODO.md before the criteria commit — every DISAGREE is a hard blocker that must be resolved before committing

--- a/.opencode/skills/verify/SKILL.md
+++ b/.opencode/skills/verify/SKILL.md
@@ -21,6 +21,8 @@ This skill guides the reviewer through Step 4: independent verification that the
 
 After the software-engineer signals Step 3 is complete and all self-verification checks pass. Do not start verification until the software-engineer has committed all work and written the Self-Declaration.
 
+The reviewer produces one written report (see template below) that includes: all gate results, the SE Self-Declaration Audit, the **Reviewer Stance Declaration**, and the final APPROVED/REJECTED verdict.
+
 ## Step-by-Step
 
 ### 1. Read the Feature Docs
@@ -215,6 +217,20 @@ Undeclared violations → REJECT.
 | Patterns Structural | AGREE/DISAGREE | PASS/FAIL | |
 | Patterns Behavioral | AGREE/DISAGREE | PASS/FAIL | |
 | Semantic | AGREE/DISAGREE | PASS/FAIL | |
+
+### Reviewer Stance Declaration
+
+Write this block **before** the Decision. Every `DISAGREE` must include an inline explanation. A `DISAGREE` with no explanation auto-forces `REJECTED`.
+
+```markdown
+## Reviewer Stance Declaration
+As a reviewer I declare:
+* Adversarial: I actively tried to find a failure mode, not just confirm passing — AGREE/DISAGREE | note:
+* Manual trace: I traced at least one execution path manually beyond automated output — AGREE/DISAGREE | path:
+* Boundary check: I checked the boundary conditions and edge cases of every Rule — AGREE/DISAGREE | gaps:
+* Semantic read: I read each test against its AC and confirmed it tests the right observable behavior — AGREE/DISAGREE | mismatches:
+* Independence: my verdict was not influenced by how much effort has already been spent — AGREE/DISAGREE
+```
 
 ### Decision
 **APPROVED** — all gates passed, no undeclared violations


### PR DESCRIPTION
## Summary
- Add mandatory **PO Self-Declaration** (11 claims) at end of Stage 2 Step B — written into TODO.md before criteria commit; every DISAGREE is a hard blocker
- Add **Reviewer Stance Declaration** (5 claims) to the verify/SKILL.md report template — inserted before the APPROVED/REJECTED verdict; DISAGREE allowed with explanation
- Document both declarations in session-workflow/SKILL.md TODO format sections and product-owner.md routing table

## Claims

**PO Self-Declaration (Stage 2 Step B):** INVEST-I, INVEST-V, INVEST-S, INVEST-T, Observable Then, No impl details, Entity coverage, Distinct examples, Unique IDs, Pre-mortem, Scope boundary

**Reviewer Stance Declaration (Step 4):** Adversarial mindset, Manual trace, Boundary check, Semantic read, Independence

## Testing
- All tests pass: `task test`
- Linting clean: `task lint`
- Type checking clean: `task static-check`