### PR TITLE
fix(workflow): add bug marker to pyproject and clarify bug handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,9 @@ Commit: `feat(criteria): write acceptance criteria for <name>`
 ### Bug Handling
 
 When a defect is reported:
-1. **PO** adds `@bug @id:<hex>` Example to the relevant `Rule:` in the `.feature` file
-2. **SE** implements the specific test in `tests/features/<feature-name>/`
-3. **SE** also writes a `@given` Hypothesis property test in `tests/unit/` for the whole class of inputs
-4. Both tests are required. SE follows the normal TDD loop (Step 3).
+1. **PO** adds a `@bug @id:<hex>` Example to the relevant `Rule:` in the `.feature` file and moves (or keeps) the feature in `backlog/` for normal scheduling.
+2. **SE** handles the bug when the feature is selected for development (standard Step 2–3 flow): implements the specific `@bug`-tagged test in `tests/features/<feature-name>/` and also writes a `@given` Hypothesis property test in `tests/unit/` covering the whole class of inputs.
+3. Both tests are required. SE follows the normal TDD loop (Step 3).
 
 ## Filesystem Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ minversion = "6.0"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "deprecated: marks tests for deprecated AC; automatically skipped (deselect with '-m \"not deprecated\"')",
+    "bug: marks tests that reproduce a reported defect (deselect with '-m \"not bug\"')",
 ]
 addopts = """
 --maxfail=10 \


### PR DESCRIPTION
## Summary

- Adds missing `bug` pytest marker to `[tool.pytest.ini_options]` in `pyproject.toml`
- Clarifies `Bug Handling` section in `AGENTS.md`: PO only tags the Example and places the feature in backlog; SE handles both the feature test and the Hypothesis property test when the feature is selected for development through the normal Step 2–3 flow

## Type

Hotfix against `v6.0.20260419 - Declarative Nautilus`