### PR TITLE
chore(release): bump version to v7.0.20260422 - Mighty Titan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this template will be documented in this file.
 
+## [v7.0.20260422] - Mighty Titan - 2026-04-22
+
+### Added
+- **PyPI publishing pipeline**: `.github/workflows/tag-release.yml` auto-tags on `pyproject.toml` version bump; `.github/workflows/pypi-publish.yml` builds, publishes via OIDC trusted publisher, and creates a GitHub Release (#100)
+- **FLOW.md state machine**: replaces `TODO.md` — static workflow state machine with auto-detection rules, prerequisites table, and session log (#100)
+- **WORK.md dynamic tracker**: active work items with `@id`, `@state`, `@branch`; append-only session log (#100)
+- **`flow` skill**: full state machine design protocol, FLOW/WORK templates, recovery from interruption (#100)
+- **`version-control` skill**: Git safety rules, branch lifecycle, commit hygiene, `--no-ff` merge protocol, post-mortem branches (#100)
+- **`architect` skill**: Step 2 architecture protocol split from `implement` (#100)
+- **System Architect agent** (`system-architect.md`): owns Step 2 (architecture) and Step 4 (adversarial review) — closed SA→SE→SA loop (#100)
+- **Post-mortem protocol**: compact post-mortem template, `fix/<stem>` branch from original start commit, `define-scope` post-mortem workflow (#100)
+- **Research library**: arc42, Google design docs, RFC/spec patterns, version-control references, Petri Nets, Statecharts, Session Types, Actor Model (entries 59–77) (#100)
+
+### Changed
+- **Project renamed to `temple8`**: `pyproject.toml`, README, `template-config.yaml`, `docs/index.html`, `setup-project` agent, git remote all updated (#100)
+- **README rewritten**: audience-first structure for developers and PMs/POs; painpoint-led personas, delivery cycle, living documentation views, development standards — no arbitrary metrics tables (#100)
+- **8-glyph in assets**: logo and banner SVG updated — `∞` in pediment replaced with `8` between the pillars (rotated 90°) (#100)
+- **SA/SE role split**: `reviewer` agent absorbed into `system-architect`; SE owns Step 3 only; SA owns Steps 2 and 4 (#100)
+- **`run-session` skill v5.0**: reads FLOW.md, detect-state protocol, branch verification, minimalist output discipline (#100)
+- **`git-release` skill**: releases from `main` only guard; `ff-only` pull; release name from `docs/branding.md` (#100)
+- **`create-pr` skill**: `--no-ff` merge; ownership moved to system-architect (#100)
+- **Skill ownership**: `git-release` → stakeholder; `create-pr` → system-architect (#100)
+- **`docs/index.html`**: 6-card landing page (system.md, context.md, features, API, coverage, research) (#100)
+- **`docs/research/`**: renamed from `docs/scientific-research/`; new entries for architecture, documentation, version-control (#100)
+
+### Removed
+- **`TODO.md`**: superseded by `FLOW.md` + `WORK.md` (#100)
+- **`.dockerignore`**: removed (#100)
+- **`docs/architecture.md`**: superseded by `docs/system.md` + `docs/adr/` (#100)
+- **`reviewer` agent**: absorbed into `system-architect` (#100)
+
 ## [v6.4.20260420] - Minimal Prometheus - 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temple8"
-version = "6.4.20260420"
+version = "7.0.20260422"
 description = "Python template with some awesome tools to quickstart any Python project"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ Documentation = "https://github.com/nullhack/temple8/tree/main/docs/api/"
 dev = [
     "pdoc>=14.0",
     "pytest>=9.0.3",
-    "pytest-beehave[html]>=3.3,<4",
+    "pytest-beehave[html]>=0.1,<1",
     "pytest-cov>=6.1.1",
     "pytest-mock>=3.14.0",
     "ruff>=0.11.5",

--- a/uv.lock
+++ b/uv.lock
@@ -748,15 +748,15 @@ wheels = [
 
 [[package]]
 name = "pytest-beehave"
-version = "3.3.20260419"
+version = "0.1.20260421"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fire" },
     { name = "gherkin-official" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/55/5cac9181f3f30a37e700e002a3d6bc51f6d9b62f3ab13a142f56bec6039f/pytest_beehave-3.3.20260419.tar.gz", hash = "sha256:86f199b213b77cec7082e0d7f96b11ba61b92fc3dcecc2f2753a07f407ad1cbe", size = 35117, upload-time = "2026-04-20T01:01:02.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/32/5ef8f7ad22dfe574c2b06d92fdd6ff6fbe3950d4076d830451089cb38a29/pytest_beehave-0.1.20260421.tar.gz", hash = "sha256:3c39384a1bf318f7d31e589bb436cd233671a1f7db04accfe34445b25b94ab64", size = 35163, upload-time = "2026-04-21T05:00:35.742Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/76/2766d4dc64137ad05128728f84bd7f2c8ef7a433d30cada289dc6c1bcd0b/pytest_beehave-3.3.20260419-py3-none-any.whl", hash = "sha256:e0048a15af8ccd9e50c0841f43ac1e90bc9d2f5f59b22048d4b79e01016c5f0a", size = 35535, upload-time = "2026-04-20T01:00:59.897Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7c/a0773bf67e013972c22ec6a3099949dcfda37be6b034e3bdca5d851058ce/pytest_beehave-0.1.20260421-py3-none-any.whl", hash = "sha256:f4efc05b0487637ef2e75a0e272960b56f4c76ede5754ca4ee46397da4399e00", size = 35553, upload-time = "2026-04-21T05:00:34.18Z" },
 ]
 
 [package.optional-dependencies]
@@ -826,56 +826,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-project-template"
-version = "6.4.20260420"
-source = { virtual = "." }
-dependencies = [
-    { name = "fire" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "ghp-import" },
-    { name = "hypothesis" },
-    { name = "pdoc" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-beehave", extra = ["html"] },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "ruff" },
-    { name = "taskipy" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "gherkin-official" },
-    { name = "safety" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fire", specifier = ">=0.7.1" },
-    { name = "ghp-import", marker = "extra == 'dev'", specifier = ">=2.1.0" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.148.4" },
-    { name = "pdoc", marker = "extra == 'dev'", specifier = ">=14.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.407" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-beehave", extras = ["html"], marker = "extra == 'dev'", specifier = ">=3.3,<4" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.5" },
-    { name = "taskipy", marker = "extra == 'dev'", specifier = ">=1.14.1" },
-]
-provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "gherkin-official", specifier = ">=39.0.0" },
-    { name = "safety", specifier = ">=3.7.0" },
 ]
 
 [[package]]
@@ -1096,6 +1046,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/44/572261df3db9c6c3332f8618fafeb07a578fd18b06673c73f000f3586749/taskipy-1.14.1.tar.gz", hash = "sha256:410fbcf89692dfd4b9f39c2b49e1750b0a7b81affd0e2d7ea8c35f9d6a4774ed", size = 14475, upload-time = "2024-11-26T16:37:46.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/97/4e4cfb1391c81e926bebe3d68d5231b5dbc3bb41c6ba48349e68a881462d/taskipy-1.14.1-py3-none-any.whl", hash = "sha256:6e361520f29a0fd2159848e953599f9c75b1d0b047461e4965069caeb94908f1", size = 13052, upload-time = "2024-11-26T16:37:44.546Z" },
+]
+
+[[package]]
+name = "temple8"
+version = "7.0.20260422"
+source = { virtual = "." }
+dependencies = [
+    { name = "fire" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "ghp-import" },
+    { name = "hypothesis" },
+    { name = "pdoc" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-beehave", extra = ["html"] },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+    { name = "taskipy" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "gherkin-official" },
+    { name = "safety" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fire", specifier = ">=0.7.1" },
+    { name = "ghp-import", marker = "extra == 'dev'", specifier = ">=2.1.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.148.4" },
+    { name = "pdoc", marker = "extra == 'dev'", specifier = ">=14.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.407" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-beehave", extras = ["html"], marker = "extra == 'dev'", specifier = ">=0.1,<1" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.5" },
+    { name = "taskipy", marker = "extra == 'dev'", specifier = ">=1.14.1" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "gherkin-official", specifier = ">=39.0.0" },
+    { name = "safety", specifier = ">=3.7.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump version to `v7.0.20260422` (major — project rename, breaking workflow changes)
- Fix `pytest-beehave` constraint from `>=3.3,<4` to `>=0.1,<1` (only `0.1.20260421` is on PyPI)
- Regenerate `uv.lock`
- Update `CHANGELOG.md` with full release notes for Mighty Titan

## Release: Mighty Titan

This is a major release marking the project's identity as **temple8** and a foundational overhaul of the AI-assisted development workflow.