### PR TITLE
fix(ci): pypi-publish workflow — add workflow_dispatch, pin artifacts, handle existing release

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v7.0.20260422)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@cdfb2ee6dde255817c739680168ad81e184c4bfb # v4.0.0
@@ -52,7 +60,7 @@ jobs:
           uv run --isolated --no-project --with dist/*.tar.gz python -c "import app; print('Source dist install successful')"
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
         with:
           name: dist
           path: dist/
@@ -67,7 +75,7 @@ jobs:
 
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
@@ -76,27 +84,34 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   release:
-    name: Create GitHub Release
+    name: Update GitHub Release
     runs-on: ubuntu-latest
     needs: publish
     permissions:
-      contents: write  # required to create a release
+      contents: write  # required to create/edit a release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            dist/*
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              dist/*
+          fi


### PR DESCRIPTION
## Problem

`pypi-publish.yml` never triggered for `v7.0.20260422` because the tag was already on the remote (created by `gh release create` manually) when `tag-release.yml` ran — so no `push: tags: v*` event was emitted.

## Changes

- **Add `workflow_dispatch`** with `tag` input — allows manual re-runs for existing tags
- **Fix `release` job**: if a GitHub Release already exists for the tag, upload dist files to it (`gh release upload --clobber`) instead of failing on `gh release create`
- **Pin `download-artifact`** to SHA `d3f86a106a0bac45b974a628896c90dbdf5c8093` (v4) — consistent with `upload-artifact` pin
- **Checkout correct ref** in both `build` and `release` jobs when triggered via `workflow_dispatch`