### PR TITLE
fix(ci): install package in editable mode for publish-docs and tag-release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+    env:
+      UV_SYSTEM_PYTHON: "false"
 
     steps:
       - name: Checkout code
@@ -187,7 +189,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked --all-extras --dev && uv pip install -e .
 
       - name: Build and publish documentation
         run: uv run task doc-publish

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      UV_SYSTEM_PYTHON: "false"
 
     steps:
       - name: Checkout code
@@ -48,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.check.outputs.exists == 'false'
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked --all-extras --dev && uv pip install -e .
 
       - name: Run release-check
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary
- `publish-docs` and `Create version tag` jobs failed with `PackageNotFoundError: No package metadata was found for temple8` because `uv sync` alone does not register the project's dist-info when `UV_SYSTEM_PYTHON=1` (the workflow-level default)
- The `test` and `build` jobs already had the correct pattern (`UV_SYSTEM_PYTHON: "false"` + `uv pip install -e .`) — applied the same fix to the two affected jobs

## Root Cause
`UV_SYSTEM_PYTHON=1` at workflow level causes `uv sync` to install deps into system Python instead of a venv. `uv run` still creates a `.venv`, but the project's dist-info is absent from it, so `importlib.metadata.metadata("temple8")` raises `PackageNotFoundError` at test time.

## Changes
- `.github/workflows/ci.yml` — `publish-docs` job: added `env: UV_SYSTEM_PYTHON: "false"` + `uv pip install -e .` after `uv sync`
- `.github/workflows/tag-release.yml` — `Create version tag` job: same fix

## Testing
- `test` job already passes with this pattern (no code changes)
- `quality` job unaffected (no pytest)
- Fix is consistent with the working pattern in `test` and `build` jobs