### PR TITLE
chore(release): bump version to v7.2.20260423 - Methodical Theseus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this template will be documented in this file.
 
+## [v7.2.20260423] - Methodical Theseus - 2026-04-23
+
+### Added
+
+- **`scripts/`**: 10 validation and automation scripts (`assign_ids.py`, `check_adrs.py`, `check_commit_messages.py`, `check_feature_file.py`, `check_oc.py`, `check_stubs.py`, `check_version.py`, `check_work_md.py`, `detect_state.py`, `score_features.py`, `update_index_html.py`) (#113)
+- **`docs/adr/ADR-2026-04-22-cli-parser-library.md`**: decision record for choosing `argparse` over click/typer (#113)
+- **`.opencode/skills/architect/adr.md.template`**: ADR template for Step 2 architectural decisions (#113)
+- **`docs/features/completed/cli-entrypoint.feature`**: completed feature file for CLI entrypoint (#113)
+- **`scripts/update_index_html.py`**: documentation portal generator (#113)
+
+### Changed
+
+- **Mermaid → markdown tables**: C4 diagrams in `system.md` and skill templates converted from Mermaid to markdown tables; British English adopted across project files (#113)
+- **ADR format restructured**: Interview Q&A table and stakeholder validation gate added to ADR template (#113)
+- **Skill and agent files updated**: `architect/SKILL.md`, `define-scope/SKILL.md`, `implement/SKILL.md`, `refactor/SKILL.md`, `update-docs/SKILL.md`, `verify/SKILL.md`, and all agent files updated with latest conventions (#113)
+- **`docs/index.html`**: redesigned documentation portal with branding palette, inline features, ADR list (#113)
+- **`docs/system.md`**: section order and domain model terminology updated (#113)
+- **`docs/glossary.md`**: expanded living glossary (#113)
+- **CI workflows**: updated for `UV_SYSTEM_PYTHON` and editable install handling (#113)
+
+### Removed
+
+- **Duplicate template files**: `define-scope/discovery-template.md`, `implement/adr.md.template`, `implement/system.md.template`, `update-docs/container.md.template`, `update-docs/context.md.template`, `update-docs/glossary.md.template` — consolidated under `architect/` (#113)
+- **Stale test files**: `tests/unit/app_test.py` (broken `main(verbosity)` call) and `tests/features/completed/display-version.feature` (superseded) (#113)
+- **`tests/conftest.py`**: manual marker skip hook removed — now owned by pytest-beehave (#113)
+
+---
+
 ## [v7.2.20260422] - Resolute Hermes - 2026-04-22
 
 ### Added

--- a/docs/features/completed/cli-entrypoint.feature
+++ b/docs/features/completed/cli-entrypoint.feature
@@ -20,7 +20,7 @@ Feature: CLI Entrypoint
   Constraints:
   - Zero new dependencies (argparse and importlib.metadata are stdlib).
   - All production code lives in `app/__main__.py` only — no new files.
-  - Version format follows the project's calver scheme (e.g. `7.1.20260422`); tests must not assume semver.
+  - Version format follows the project's calver scheme (e.g. `7.2.20260423`); tests must not assume semver.
 
   Rule: Help output
     As a developer using the template

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -103,7 +103,7 @@ Entries are sorted alphabetically.
 
 **Aliases:** entry point, main module, CLI entry
 
-**Example:** "Running `python -m app --version` invokes the CLI entrypoint and prints `temple8 7.1.20260422`."
+**Example:** "Running `python -m app --version` invokes the CLI entrypoint and prints `temple8 7.2.20260423`."
 
 **Source:** 2026-04-22 — Session 1; feature `cli-entrypoint`
 
@@ -175,7 +175,7 @@ Entries are sorted alphabetically.
 
 **Aliases:** project metadata, distribution metadata
 
-**Example:** "`importlib.metadata.version('temple8')` returns `7.1.20260422` at runtime, matching the `version` field in `pyproject.toml`."
+**Example:** "`importlib.metadata.version('temple8')` returns `7.2.20260423` at runtime, matching the `version` field in `pyproject.toml`."
 
 **Source:** 2026-04-22 — Session 1 (Q10, Q11); feature `cli-entrypoint`
 

--- a/docs/system.md
+++ b/docs/system.md
@@ -125,7 +125,7 @@ See `docs/adr/` for the full decision record.
 |-----|------|---------|-------------|
 | `project.name` | string | `"temple8"` | Application name; read from installed package metadata |
 | `project.description` | string | `"Python template with some awesome tools to quickstart any Python project"` | Package description from `pyproject.toml`; set as `argparse` description |
-| `project.version` | string | `"7.1.20260422"` | Calver version; read at runtime via `importlib.metadata` |
+| `project.version` | string | `"7.2.20260423"` | Calver version; read at runtime via `importlib.metadata` |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temple8"
-version = "7.2.20260422"
+version = "7.2.20260423"
 description = "Python template with some awesome tools to quickstart any Python project"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "temple8"
-version = "7.2.20260422"
+version = "7.2.20260423"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Version bump `7.2.20260422` → `7.2.20260423` (minor)
- Release name: **Methodical Theseus**
- Updated CHANGELOG.md, docs/system.md, docs/glossary.md version references, uv.lock

## Testing
- `uv run task release-check` passes (version alignment, lint, static-check, tests, doc-build)
- Coverage: 100%