### PR TITLE
fix(ci): install package in editable mode for PyPI publish quality gate

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras --dev
 
+      - name: Install package in editable mode
+        run: uv pip install -e .
+
       - name: Run quality gate
         run: |
           uv run task lint


### PR DESCRIPTION
## Summary
- Add `uv pip install -e .` step before quality gate in `pypi-publish.yml`
- Fixes `PackageNotFoundError: No package metadata was found for temple8` that causes all CLI tests to fail in the publish workflow

## Testing
- Same fix already applied in `ci.yml` (see `fix/ci-install` branch history)