### PR TITLE
docs: rewrite README with problem statement, persona sections, and flow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![MIT License][license-shield]][license-url]
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?style=for-the-badge)](https://nullhack.github.io/temple8/coverage/)
 [![CI](https://img.shields.io/github/actions/workflow/status/nullhack/temple8/ci.yml?style=for-the-badge&label=CI)](https://github.com/nullhack/temple8/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/badge/python-3.13-blue?style=for-the-badge)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-%E2%89%A513-blue?style=for-the-badge)](https://www.python.org/downloads/)
 
 **From zero to hero — production-ready Python, without the ceremony.**
 
@@ -19,9 +19,43 @@
 
 ---
 
-A delivery system that treats documentation as a first-class artifact and enforces production rigor through an AI-assisted workflow. Your team ships features, not broken promises.
+You have tried to ship features with AI assistants. The agent writes code, you review it, and somehow the spec still drifts from the implementation. Tests pass but the feature doesn't match what stakeholders asked for. Architecture decisions vanish into commit messages nobody reads. The review cycle is a black box — either everything passes or nothing does, with no structured progression.
 
-Developers get TDD by default with traceability from requirement to test. Product Owners get living documentation that never drifts from code. Architects get adversarial review that catches what automated checks miss.
+**temple8 replaces ad-hoc agent orchestration with state machines that route every step through the right agent with the right skills at the right time.**
+
+Flow definitions in YAML declare what happens at each state: who owns it, what they may read, what they must produce, and which conditions gate the next transition. No agent guesses what to do next. No step is skipped. No artifact is written outside its contract.
+
+---
+
+## Who is this for?
+
+### Developers — TDD with traceability, not just coverage
+
+You write BDD scenarios from stakeholder interviews. Tests are linked to feature specs with `@id` tags. Every `Given/When/Then` maps to a test function. No orphan tests, no missing tests. Red-green-refactor cycles are enforced — you can't skip to implementation.
+
+### Product Owners — Living documentation that never drifts
+
+Feature files are the contract. Acceptance criteria are BDD scenarios, not bullet points in a ticket. The delivery flow tracks whether a feature is `BASELINED`, `ACCEPTED`, or rejected — with evidence at every gate. You see exactly what was built and why.
+
+### Architects — Adversarial review that catches what linters miss
+
+Three-tier review: design alignment (does it match the domain model?), structure (coverage, traceability, coupling), conventions (formatting, naming, lint). Each tier can fail independently. No rubber-stamping through one monolithic gate.
+
+---
+
+## What it does
+
+```
+flowr check      →  inspect a state's owner, skills, and transitions
+flowr next       →  see which transitions pass given your evidence
+flowr transition →  advance to the next state with evidence
+```
+
+**State machines route the work.** YAML flows define the delivery pipeline — discovery, architecture, planning, TDD cycles, review gates, delivery. Each state declares an owner, skills, input/output artifacts, and guard conditions. The engine validates transitions. The agent executes.
+
+**Agents execute it.** Each state's `owner` dispatches to the right agent (PO, SE, SA, DE, R). Skills are loaded per state. Input/output contracts prevent scope creep. Evidence gates prevent premature transitions.
+
+**Branch discipline is explicit.** Every state declares `git: main` or `git: feature`. Project-phase work commits to main. Feature work commits to a feature branch. No ambiguity about where changes belong.
 
 ---
 
@@ -53,9 +87,9 @@ uv run task doc-build     # build API docs + coverage report
 
 ## Documentation
 
-- **[Product Definition](docs/product-definition.md)** — product boundaries, users, and scope
-- **[System Overview](docs/system.md)** — architecture, domain model, module structure, and constraints
-- **[Glossary](docs/glossary.md)** — living domain glossary
+- **[Product Definition](https://nullhack.github.io/temple8/)** — product boundaries, users, and scope
+- **[System Overview](https://nullhack.github.io/temple8/)** — architecture, domain model, module structure, and constraints
+- **[Glossary](https://nullhack.github.io/temple8/)** — living domain glossary
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrote README following agents-smith best practices: problem statement ("You have tried..."), persona sections (Developers, POs, Architects), and "What it does" with flowr command overview
- Fixed broken doc links pointing to non-existent local files → now point to GitHub Pages
- Updated Python badge to use ≥13 format