### PR TITLE
feat: adversarial design principle verification in review-gate (v8.5.1)

### DIFF
--- a/.opencode/knowledge/software-craft/code-review.md
+++ b/.opencode/knowledge/software-craft/code-review.md
@@ -22,7 +22,7 @@ last-updated: 2026-05-14
 
 **Fail-Fast Protocol**. Stop reviewing at the first defect found. Write a minimal REJECTED report containing: the defect, its file:line evidence, and the required action. Do not accumulate multiple findings. The first defect may invalidate everything that follows. Fix the defect, re-submit, and the reviewer starts over.
 
-**Two-Tier Review**. Each tier checks a different quality dimension with different knowledge. Design review verifies alignment with domain spec, ADRs, and quality attributes. Structure review verifies test coverage, test quality, abstraction level matching, and functional lint (bug-catching rules only). Conventions (naming, docstrings, formatting, type annotations) are enforced in a separate polish state after feature acceptance, not during review.
+**Two-Tier Review**. Each tier checks a different quality dimension with different knowledge. Design review verifies alignment with domain spec, ADRs, and quality attributes, then independently verifies design principles (YAGNI > KISS > DRY > ObjCal > Smells > SOLID > patterns) by loading the relevant knowledge files. Structure review verifies test coverage, test quality, abstraction level matching, and functional lint (bug-catching rules only). Conventions (naming, docstrings, formatting, type annotations) are enforced in a separate polish state after feature acceptance, not during review.
 
 **Self-Declaration as Commitment Device** (Hattie & Timperley, 2007; Cialdini, 2001). Before handoff, the developer declares specific quality attributes as AGREE/DISAGREE. This forces explicit judgment on each criterion, preventing the "I skimmed it and nothing jumped out" pattern. DISAGREE is not automatic rejection. The developer states the reason, and the reviewer evaluates whether the reason is acceptable.
 
@@ -33,7 +33,7 @@ last-updated: 2026-05-14
 
 | Tier | Checks | Key Knowledge |
 |---|---|---|
-| Design | Domain alignment, ADR consistency, quality attributes, design principle priority | [[architecture/reconciliation]], [[architecture/adr]] |
+| Design | Domain alignment, ADR consistency, quality attributes, design principles (YAGNI > KISS > DRY > ObjCal > Smells > SOLID > patterns) | [[architecture/reconciliation]], [[architecture/adr]], [[software-craft/tdd]], [[software-craft/object-calisthenics]], [[software-craft/smell-catalogue]], [[software-craft/solid]], [[software-craft/design-patterns]] |
 | Structure | Test coverage, test quality, abstraction level, observable behaviour, functional lint | [[software-craft/test-design]], [[software-craft/tdd]] |
 
 Conventions (naming, docstrings, formatting, type annotations, full lint) are enforced in a separate polish state after feature acceptance via `task conventions`, `ruff format`, and `task static-check`.

--- a/.opencode/skills/review-gate/SKILL.md
+++ b/.opencode/skills/review-gate/SKILL.md
@@ -14,7 +14,15 @@ Available knowledge: [[software-craft/code-review]], [[software-craft/test-desig
 1. Verify implementation aligns with domain spec per [[software-craft/code-review#concepts]]: entities match domain spec, value objects enforce invariants, use cases follow aggregate boundaries.
 2. Verify implementation aligns with architectural decisions per [[software-craft/code-review#concepts]]: ADR compliance, quality attributes met.
 3. Verify implementation aligns with feature specification: all Examples have corresponding test implementations, behavior matches Gherkin steps.
-4. **FAIL-FAST**: If any design violations found → exit `fail` with specific citations (file:line). Do NOT proceed to structure review.
+4. Verify design principles adversarially per [[software-craft/tdd#key-takeaways]] priority order (YAGNI > KISS > DRY > ObjCal > Smells > SOLID > patterns):
+   - **YAGNI**: No premature abstractions, no speculative generalization, no code without an exercising test.
+   - **KISS**: No unnecessary complexity or over-engineering when a simpler solution exists.
+   - **DRY**: No duplicated logic, unless the duplication is simpler than the wrong abstraction (KISS overrides DRY).
+   - **ObjCal**: Load [[software-craft/object-calisthenics#key-takeaways]] — check 9 rules: one level of indentation, no `else`, wrapped primitives, one dot per line, no abbreviations, small entities, ≤2 instance variables, first-class collections, no getters/setters.
+   - **Smells**: Load [[software-craft/smell-catalogue#key-takeaways]] — check for bloaters, OO abusers, change preventers, dispensables, couplers.
+   - **SOLID**: Load [[software-craft/solid#key-takeaways]] — check SRP, OCP, LSP, ISP, DIP violations.
+   - **Patterns**: Verify every design pattern is driven by a smell. Patterns without a motivating smell violate YAGNI.
+5. **FAIL-FAST**: If any design violations found → exit `fail` with specific citations (file:line). Do NOT proceed to structure review.
 
 ## Tier 2: Structure Review
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temple8"
-version = "8.5.0"
+version = "8.5.1"
 description = "Spec-driven agent orchestration template with YAML flow definitions, multi-agent dispatch, and BDD traceability"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "temple8"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Added explicit design principle checks to review-gate Tier 1**: The reviewer now independently verifies YAGNI > KISS > DRY > ObjCal > Smells > SOLID > patterns by loading the relevant knowledge files, rather than relying solely on SE self-declaration.
- **Updated code-review.md**: Two-Tier Review concept and table now document the adversarial design principle verification with knowledge file references.

## Changes

- `.opencode/skills/review-gate/SKILL.md`: Added step 4 to Tier 1 with 7 sub-checks, each referencing its knowledge file
- `.opencode/knowledge/software-craft/code-review.md`: Updated Two-Tier Review concept text and Design row in review structure table
- `pyproject.toml`: Bump to 8.5.1
- `uv.lock`: Updated

**Full Changelog**: https://github.com/nullhack/temple8/compare/v8.5.0...v8.5.1