### PR TITLE
fix: sync uv.lock after version bump and dependabot merges

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "temple8"
-version = "8.5.1"
+version = "8.6.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The lockfile was out of date after dependabot merges preceded the version bump squash merge. `uv lock` fixes it.