### PR TITLE
feat(git): v9.4.0 branch lifecycle discipline

### DIFF
--- a/.opencode/knowledge/software-craft/git-conventions.md
+++ b/.opencode/knowledge/software-craft/git-conventions.md
@@ -1,7 +1,7 @@
 ---
 domain: software-craft
 tags: [git, branching, commits, squash, pull-requests, conflict-resolution]
-last-updated: 2026-05-14
+last-updated: 2026-05-28
 ---
 
 # Git Conventions
@@ -9,7 +9,8 @@ last-updated: 2026-05-14
 ## Key Takeaways
 
 - Feature branches use granular commits per achievement; local dev receives single squashed commits per feature.
-- Before merging to local dev: pull latest remote dev, resolve any conflicts feature by feature, then squash-merge.
+- Before merging to local dev: sync main with remote, reset dev to origin/main, then squash-merge. Delete feature branch after merge.
+- After PR merge to main: reset local dev to origin/main to prevent history divergence on next PR.
 - Granular commit format: `<type>(<scope>): <specific achievement>` (e.g., `feat(auth): add JWT signing method`).
 - Squashed commit format includes Example title traceability, feature metadata, and approval trail.
 - Multiple features can accumulate on local dev before creating a PR: the stakeholder decides when to publish.
@@ -21,9 +22,11 @@ last-updated: 2026-05-14
 
 **Local Dev as Staging Area**. Local dev accumulates squashed feature commits. Multiple features can be developed and squash-merged to local dev before publishing to remote. This allows integration testing of multiple features together and reduces PR noise. The stakeholder decides after each feature whether to continue developing more features or publish the batch. PRs go from dev to main on the remote.
 
-**Conflict Prevention**. Before squash-merging, pull the latest remote dev to detect conflicts early. Resolve conflicts feature by feature on the feature branch. If conflicts require design decisions, present options to the stakeholder with consequences.
+**Conflict Prevention**. Before squash-merging, sync local main with remote (`git merge --ff-only origin/main`), then reset local dev to origin/main to prevent history divergence from previous PR merges. Resolve conflicts feature by feature on the feature branch. If conflicts require design decisions, present options to the stakeholder with consequences.
 
-**Administrative PR**. The PR (dev → main) serves the git hosting platform's approval requirement, not merge mechanics. Changes are already on local dev. The PR documents what was built, provides traceability via Example titles, and enables the review/approval workflow.
+**Administrative PR**. The PR (dev → main) serves the git hosting platform's approval requirement, not merge mechanics. Changes are already on local dev. The PR documents what was built, provides traceability via Example titles, and enables the review/approval workflow. After the PR is squash-merged to main on the remote, sync local main and reset local dev to origin/main so the next feature cycle starts clean.
+
+**Branch Lifecycle**. Feature branches are short-lived: create from main, develop, squash-merge to dev, delete. No feature branch persists after its squash-merge. This prevents stale branches from accumulating and ensures a clean `git branch` output. Only `main` and `dev` are long-lived branches.
 
 **Conventional Commits**. Every commit follows `<type>(<scope>): <description>`. Types: `feat` (feature), `fix` (bug fix), `test` (test addition/modification), `refactor` (structural change with no behavior change), `chore` (tooling, deps, CI), `docs` (documentation). Forbidden: `wip`, `temp`, any commit without a type prefix.
 

--- a/.opencode/skills/create-pr/SKILL.md
+++ b/.opencode/skills/create-pr/SKILL.md
@@ -12,3 +12,8 @@ Available knowledge: [[software-craft/git-conventions#key-takeaways]]. `in` arti
 3. IF the PR is approved → write results to output artifacts, advance to next state.
 4. IF changes are requested → address feedback on a fix branch per [[software-craft/git-conventions#concepts]], then re-push and update the PR.
 5. IF the PR is cancelled → write results to output artifacts, route to post-mortem.
+6. After PR is merged to main on remote: sync local branches for next cycle.
+   - `git fetch origin`
+   - `git checkout main && git merge --ff-only origin/main`
+   - `git checkout dev && git reset --hard origin/main`
+   - This prevents history divergence on the next dev → main PR.

--- a/.opencode/skills/merge-local/SKILL.md
+++ b/.opencode/skills/merge-local/SKILL.md
@@ -7,12 +7,15 @@ description: "Squash-merge feature commits into local dev branch, pull remote de
 
 Available knowledge: [[software-craft/git-conventions#key-takeaways]]. `in` artifacts: read all before starting work.
 
-1. Pull latest remote dev: `git fetch origin dev && git checkout dev && git merge --ff-only origin/dev`.
-2. If remote dev has diverged, rebase the feature branch on updated dev before squash-merging.
-3. Squash all feature commits into a single commit per [[software-craft/git-conventions#concepts]].
-4. Merge the squashed commit into local dev.
-5. Run feature-type verification per [[software-craft/git-conventions#content]].
-6. Run `uv run task test-fast` to verify all tests pass on local dev.
-7. If conflicts arise during rebase or merge:
-   - IF the conflict is a straightforward text merge → resolve and continue.
-   - IF the conflict requires a design decision → present options to the stakeholder with consequences before resolving.
+1. Sync local main with remote: `git fetch origin && git checkout main && git merge --ff-only origin/main`.
+2. Sync local dev with main (handles post-PR divergence): `git checkout dev && git reset --hard origin/main`. IF origin/main does not exist yet (first feature), pull remote dev instead: `git merge --ff-only origin/dev`.
+3. Pull latest remote dev for safety: `git merge --ff-only origin/dev`. IF this fails (dev diverged from remote dev), reset to origin/main per step 2 and proceed.
+4. IF the feature branch needs updates from dev, rebase the feature branch on dev before squash-merging.
+5. Squash all feature commits into a single commit per [[software-craft/git-conventions#concepts]].
+6. Merge the squashed commit into local dev.
+7. Run feature-type verification per [[software-craft/git-conventions#content]].
+8. Run `uv run task test-fast` to verify all tests pass on local dev.
+9. Delete the feature branch: `git branch -d <feature-branch>`. IF the branch has unmerged work (check `git log dev..<feature-branch>`), abort and report.
+10. IF conflicts arise during rebase or merge:
+    - IF the conflict is a straightforward text merge → resolve and continue.
+    - IF the conflict requires a design decision → present options to the stakeholder with consequences before resolving.

--- a/.opencode/skills/structure-feature/SKILL.md
+++ b/.opencode/skills/structure-feature/SKILL.md
@@ -7,5 +7,5 @@ description: "Create feature branch and package structure from design artifacts"
 
 Available knowledge: [[software-craft/source-stubs#concepts]], [[software-craft/git-conventions#key-takeaways]]. `in` artifacts: read all before starting work.
 
-1. Create feature branch per [[software-craft/git-conventions#content]]: `feat/<stem>` from latest main. `out: git_branch` is a Runtime artifact — the output of this step IS the branch creation, not a file on disk.
+1. Sync local main with remote: `git fetch origin && git checkout main && git merge --ff-only origin/main`. Create feature branch per [[software-craft/git-conventions#content]]: `feat/<stem>` from updated main. `out: git_branch` is a Runtime artifact — the output of this step IS the branch creation, not a file on disk.
 2. Create package structure per [[software-craft/source-stubs#concepts]] and [[architecture/technical-design#key-takeaways]].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this template will be documented in this file.
 
+## [v9.4.0] - 2026-05-28: Branch Lifecycle Discipline
+
+### Changed
+
+- **merge-local/SKILL.md**: sync local main with remote before merge, reset dev to origin/main to prevent history divergence, delete feature branch after squash-merge
+- **create-pr/SKILL.md**: after PR merged, sync local main and reset dev to origin/main for clean next cycle
+- **structure-feature/SKILL.md**: pull remote main before creating feature branch from current main
+- **git-conventions.md**: added Branch Lifecycle concept (short-lived feature branches, only main/dev persist), updated Conflict Prevention and Administrative PR sections with post-merge sync discipline
+
 ## [v9.3.0] - 2026-05-28: V10 Agentic Reform
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temple8"
-version = "9.3.0"
+version = "9.4.0"
 description = "Spec-driven agent orchestration template with YAML flow definitions, multi-agent dispatch, and BDD traceability"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "temple8"
-version = "9.3.0"
+version = "9.4.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Prevents merge conflicts from diverged dev/main histories by enforcing a branch lifecycle discipline across three skills and the git conventions knowledge base.

### Changes

- **merge-local/SKILL.md**: sync main with remote, reset dev to `origin/main` before squash-merge, delete feature branch after merge
- **create-pr/SKILL.md**: after PR merged, sync local main and reset dev to `origin/main` for clean next cycle
- **structure-feature/SKILL.md**: pull remote main before creating feature branch
- **git-conventions.md**: added Branch Lifecycle concept (short-lived feature branches, only main/dev persist), updated Conflict Prevention and Administrative PR sections

### Why

After a PR is squash-merged (dev → main on GitHub), local dev retains its original history while main has a new squash commit. The next PR (dev → main) conflicts because histories diverged. Fix: reset dev to `origin/main` after each PR merge and before each squash-merge.